### PR TITLE
Remove sample scripts from production distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.* export-ignore
+/callback.php export-ignore
+/clearsessions.php export-ignore
+/config-sample.php export-ignore
+/connect.php export-ignore
+/html.inc export-ignore
+/index.php export-ignore
+/redirect.php export-ignore
+/test.php export-ignore


### PR DESCRIPTION
These files are not useful for production machines, they are just examples.

Developers that need them could still do a `git clone` (or take a look at this repo on GitHub :wink:)
